### PR TITLE
Update PlayTextEditorView.swift

### DIFF
--- a/SwiftPamphletApp/Resource/Play/SwiftUI/ViewComponent/PlayTextEditorView.swift
+++ b/SwiftPamphletApp/Resource/Play/SwiftUI/ViewComponent/PlayTextEditorView.swift
@@ -16,7 +16,7 @@ struct PlayTextEditorView: View {
     // for CodeEditorView
     @Environment(\.colorScheme) private var colorScheme: ColorScheme
     @State private var codeMessages: Set<Located<Message>> = Set ()
-    @SceneStorage("editLocation") private var editLocation: CodeEditor.Location = CodeEditor.Location()
+    @SceneStorage("editLocation") private var editLocation: CodeEditor.Position  = CodeEditor.Position()
     var body: some View {
         
         // 使用 SwiftUI 自带 TextEditor
@@ -65,7 +65,7 @@ static func number() {
     let i3 = 36
     print(i3.isMultiple(of: 9)) // true
 }
-"""),
+"""), position: $editLocation,
                    messages: $codeMessages,
                    language: .swift,
                    layout: CodeEditor.LayoutConfiguration(showMinimap: true)
@@ -237,6 +237,3 @@ final class PNSTextConfiguredView: NSView {
     } // end viewWillDraw
 
 }
-
-
-


### PR DESCRIPTION
CodeEditorView升级到0.10.0后：
1、CodeEditor.Location替换为CodeEditor.Position
2、CodeEditor参数position不再是可选参数